### PR TITLE
Add noopener to every "a" tag

### DIFF
--- a/src/social-icon.js
+++ b/src/social-icon.js
@@ -18,6 +18,7 @@ function SocialIcon(props) {
     <a
       href={url}
       target="_blank"
+      rel="noopener"
       className={cx('social-icon', className)}
       style={socialIcon}
       {...rest}


### PR DESCRIPTION
Add rel="noopener" to every link to improve performance and prevent security vulnerabilities
(see : https://developers.google.com/web/tools/lighthouse/audits/noopener)